### PR TITLE
Added support for expressions in attributes

### DIFF
--- a/angular-spinner.js
+++ b/angular-spinner.js
@@ -26,25 +26,27 @@
 		.directive('usSpinner', ['$window', function ($window) {
 			return {
 				scope: true,
-				controller: ['$scope', '$element', '$attrs', function ($scope, $element, $attrs) {
-					$scope.spinner = null;
-					$scope.key = angular.isDefined($attrs.spinnerKey) ? $attrs.spinnerKey : false;
-					$scope.startActive = angular.isDefined($attrs.spinnerStartActive) ?
-						$attrs.spinnerStartActive : !($scope.key);
-
-					$scope.spin = function () {
-						if ($scope.spinner) {
-							$scope.spinner.spin($element[0]);
-						}
-					};
-
-					$scope.stop = function () {
-						if ($scope.spinner) {
-							$scope.spinner.stop();
-						}
-					};
-				}],
 				link: function (scope, element, attr) {
+					scope.spinner = null;
+
+					scope.key = angular.isDefined(attr.spinnerKey) ? attr.spinnerKey : false;
+
+					scope.startActive = angular.isDefined(attr.spinnerStartActive) ?
+						attr.spinnerStartActive : scope.key ?
+						false: true;
+
+					scope.spin = function () {
+						if (scope.spinner) {
+							scope.spinner.spin(element[0]);
+						}
+					};
+
+					scope.stop = function () {
+						if (scope.spinner) {
+							scope.spinner.stop();
+						}
+					};
+					
 					scope.$watch(attr.usSpinner, function (options) {
 						scope.stop();
 						scope.spinner = new $window.Spinner(options);


### PR DESCRIPTION
Added support for expressions in spinner-key attribute (i.e. spinner-key="{{spinnerKey}}") Attributes exposed to the controller of a directive will not interpolate expressions. If an expression is provided for an attribute that is being passed into the controller the only way to interpolate it is to use $attrs.$observe() or $scope.$eval() which is evil.

According to the Angular documentation, it is a best practice to "use controller when you want to expose an API to other directives. Otherwise use link." (see: https://docs.angularjs.org/guide/directive (very bottom of the page).
