### PR TITLE
Add a `main` field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
 	"name": "angular-spinner",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"repository": {
 		"type": "git",
 		"url": "http://github.com/urish/angular-spinner.git"
 	},
+	"main": "angular-spinner.js",
 	"dependencies": {},
 	"devDependencies": {
 		"grunt": "~0.4.1",


### PR DESCRIPTION
Hey @urish it's Elfrey [again](https://github.com/urish/angular-spinner/issues/5).

We're still actively using `angular-spinner` with [browserify](http://browserify.org/). However, without a `main` field in the `package.json`, we have to do some ghetto workarounds to use it with browserify.

It'd be nice to have it to enrich the quality of our lives. :earth_africa:

Afterwards, make sure to publish the changes to `npm`.
