### PR TITLE
Bugfix: Stop events are ignored if sent before the directive is fully initialized and `startActive` is true

### DIFF
--- a/angular-spinner.js
+++ b/angular-spinner.js
@@ -47,15 +47,16 @@
 						};
 
 						scope.stop = function () {
+							scope.startActive=false;
 							if (scope.spinner) {
 								scope.spinner.stop();
 							}
 						};
 
 						scope.$watch(attr.usSpinner, function (options) {
-							scope.stop();
 							scope.spinner = new SpinnerConstructor(options);
 							if (!scope.key || scope.startActive) {
+								scope.stop();
 								scope.spinner.spin(element[0]);
 							}
 						}, true);


### PR DESCRIPTION
When startactive is true. We can send a stop event before initialization. Then the spin rotates indefinitely. I deactivated the startactive during the stop event to prevent this behavior
