### PR TITLE
Added configurable default options

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ You can also pass spinner options, for example:
 
 Possible configuration options are described in the [spin.js homepage](http://fgnass.github.io/spin.js/).
 
+### Configuring default spinner options
+
+You can use `usSpinnerConfigProvider` to configure default options for all spinners globally. Any options passed from a directive still override these.
+
+```js
+myapp.config(['usSpinnerConfigProvider', function (usSpinnerConfigProvider) {
+    usSpinnerConfigProvider.setDefaults({color: 'blue'});
+}]);
+```
+
 ### Using the usSpinnerService to control spinners
 
 ```html
@@ -79,7 +89,7 @@ The spinner-key will be used as an identifier (not unique) allowing you to have 
 
 ### Example
 
-See [online example on Plunker](http://plnkr.co/edit/BGLUYcylbIVJRz6ztbhf?p=preview). 
+See [online example on Plunker](http://plnkr.co/edit/BGLUYcylbIVJRz6ztbhf?p=preview).
 
 ## License
 

--- a/angular-spinner.js
+++ b/angular-spinner.js
@@ -12,6 +12,21 @@
 		angular
 			.module('angularSpinner', [])
 
+			.provider('usSpinnerConfig', function () {
+				var _config = {};
+
+				return {
+					setDefaults: function (config) {
+						_config = config || _config;
+					},
+					$get: function () {
+						return {
+							config: _config
+						};
+					}
+				};
+			})
+
 			.factory('usSpinnerService', ['$rootScope', function ($rootScope) {
 				var config = {};
 
@@ -26,7 +41,7 @@
 				return config;
 			}])
 
-			.directive('usSpinner', ['$window', function ($window) {
+			.directive('usSpinner', ['$window', 'usSpinnerConfig', function ($window, usSpinnerConfig) {
 				return {
 					scope: true,
 					link: function (scope, element, attr) {
@@ -59,6 +74,14 @@
 
 						scope.$watch(attr.usSpinner, function (options) {
 							stopSpinner();
+
+							options = options || {};
+							for (var property in usSpinnerConfig.config) {
+							    if (options[property] === undefined) {
+							        options[property] = usSpinnerConfig.config[property];
+							    }
+							}
+
 							scope.spinner = new SpinnerConstructor(options);
 							if (!scope.key || scope.startActive) {
 								scope.spinner.spin(element[0]);

--- a/tests.js
+++ b/tests.js
@@ -4,6 +4,20 @@
 
 'use strict';
 
+describe('Provider: usSpinnerConfigProvider', function () {
+	beforeEach(module('angularSpinner'));
+
+	it('should have configurable options', function () {
+		module(function (usSpinnerConfigProvider) {
+			usSpinnerConfigProvider.setDefaults({color: 'black'});
+		});
+
+		inject(function (usSpinnerConfig) {
+			expect(usSpinnerConfig.config.color).toBe('black');
+		});
+	});
+});
+
 describe('Directive: us-spinner', function () {
 	var Spinner;
 


### PR DESCRIPTION
Hey,

I added some configurable options with a provider that creates usSpinnerConfig object. You can now configure defaults for any spinner on application startup, they can still be overridden with the directive options. Karma tests are included in the PR. 

Example of configuration:

```
angular.module('myApp', ['angularSpinner'])
  .config(['usSpinnerConfigProvider', function (usSpinnerConfigProvider) {
    usSpinnerConfigProvider.setDefaults({color: 'blue'});
  }]);
```
