### PR TITLE
Return the created AngularJS module

### DIFF
--- a/angular-spinner.js
+++ b/angular-spinner.js
@@ -9,7 +9,7 @@
 
 	function factory(angular, Spinner) {
 
-		angular
+		return angular
 			.module('angularSpinner', [])
 
 			.provider('usSpinnerConfig', function () {


### PR DESCRIPTION
Return the created AngularJS module in the factory function to enable clients to get the module object with requiring AngularSpinner as AMD module.
