### PR TITLE
CommonJS support

### DIFF
--- a/angular-spinner.js
+++ b/angular-spinner.js
@@ -116,7 +116,7 @@
 
     if ((typeof module === 'object') && module.exports) {
 		/* CommonJS module */
-		module.exports = factory(require('angular'), require('spin.js'));
+		module.exports = factory(window.angular, require('spin.js'));
 	} else if (typeof define === 'function' && define.amd) {
 		/* AMD module */
 		define(['angular', 'spin'], factory);


### PR DESCRIPTION
Do not require angular, use window.angular instead.
This approach is more safety.

Assume you have in your project two version of angular, one installed via NPM and one stored locally (use case: part of your application needs IE8 support).
If you try to get angular with require('angular') you'll always get the latest version that installed via NPM.
In the other hand, if you use window.angular you'll get the pre loaded angular for the application.
