### PR TITLE
Webpack complains module "spin" not found. It should be "spin.js". 

### DIFF
--- a/angular-spinner.js
+++ b/angular-spinner.js
@@ -129,7 +129,7 @@
 		module.exports = factory(require('angular'), require('spin.js'));
 	} else if (typeof define === 'function' && define.amd) {
 		/* AMD module */
-		define(['angular', 'spin'], factory);
+		define(['angular', 'spin.js'], factory);
 	} else {
 		/* Browser global */
 		factory(root.angular, root.Spinner);


### PR DESCRIPTION
In the code for supporting AMD module (line 132), the module name should be "spin.js", not "spin". 
When package with Webpack, Webpack complains it can't find module "spin". 
